### PR TITLE
Use test suites to control execution

### DIFF
--- a/tests/bemioTest.m
+++ b/tests/bemioTest.m
@@ -8,17 +8,11 @@ classdef bemioTest < matlab.unittest.TestCase
         nemohDir = '';
         capytaineDir = '';
         aqwaDir = '';
-        runBEMIO = [];
     end
     
     methods (Access = 'public')
-        function obj = bemioTest(runBEMIO)
-            arguments
-                runBEMIO (1,1) double = 1;
-            end
-            
-            % Assign arguments to test Class
-            obj.runBEMIO = runBEMIO;
+        
+        function obj = bemioTest
             
             % Set WEC-Sim, test and BEMIO example directories
             obj.testDir = fileparts(mfilename('fullpath'));
@@ -31,27 +25,34 @@ classdef bemioTest < matlab.unittest.TestCase
             
             % Hide figures
             set(0,'DefaultFigureVisible','off')
+            
         end
+        
     end
     
     methods(TestMethodTeardown)
+        
         function closePlotsHydro(testCase)
             close(waitbar(0));
             close all
             clear hydro
             set(0,'DefaultFigureVisible','off')
         end
+        
     end
     
     methods(TestClassTeardown)
+        
         function cdToTestDir(testCase)
             cd(testCase.testDir);
         end
+        
     end
     
     methods(Test)
+        
         function combine_bem(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
+
             cd(fullfile(testCase.capytaineDir,'Cylinder'))
             
             hydro = struct();
@@ -61,10 +62,11 @@ classdef bemioTest < matlab.unittest.TestCase
             hydro = Read_WAMIT(hydro,'..\..\WAMIT\Cylinder\cyl.out',[]);
             hydro(end).body = {'cylinder_wamit'};
             hydro = Combine_BEM(hydro);
+            
         end
         
         function complete_BEMIO(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
+
             cd(fullfile(testCase.nemohDir,'Cylinder'))
             
             hydro = struct();
@@ -74,34 +76,33 @@ classdef bemioTest < matlab.unittest.TestCase
             hydro = Excitation_IRF(hydro,5,[],[],[],[]);
             Write_H5(hydro)
             Plot_BEMIO(hydro)
+            
         end
         
         function read_wamit(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
             cd(fullfile(testCase.wamitDir,'RM3'))
             hydro = struct();
             hydro = Read_WAMIT(hydro,'rm3.out',[]);
         end
         
         function read_nemoh(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
             cd(fullfile(testCase.nemohDir,'RM3'))
             hydro = struct();
             hydro = Read_NEMOH(hydro,'..\RM3\');
         end
         
         function read_capytaine(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
             cd(fullfile(testCase.capytaineDir,'RM3'))
             hydro = struct();
             hydro = Read_CAPYTAINE(hydro,'.\rm3_full.nc');
         end
         
         function read_aqwa(testCase)
-            testCase.assumeEqual(testCase.runBEMIO,1,'Test off (runBEMIO=0).')
             cd(fullfile(testCase.aqwaDir,'Example'))
             hydro = struct();
-            hydro = Read_AQWA(hydro,'aqwa_example_data.AH1','aqwa_example_data.LIS');
+            hydro = Read_AQWA(hydro,                    ...
+                              'aqwa_example_data.AH1',  ...
+                              'aqwa_example_data.LIS');
         end
         
     end

--- a/tests/compilationTest.m
+++ b/tests/compilationTest.m
@@ -2,32 +2,31 @@ classdef compilationTest < matlab.unittest.TestCase
     
     properties
         testDir = '';
-        wsDir = '';
         testAppDir = '';
         applicationsDir = '';
         runComp = [];
     end
     
     methods (Access = 'public')
-        function obj = compilationTest(applicationsDir,runComp)
+        
+        function obj = compilationTest(applicationsDir)
+            
             arguments
                 applicationsDir = fullfile(fileparts(mfilename('fullpath')),'..\..\WEC-Sim_Applications');
-                runComp (1,1) double = 1;
             end
-            
-            % Assign arguments to test Class
-            obj.runComp = runComp;
             
             % Set WEC-Sim, test and applications directories
             obj.testDir = fileparts(mfilename('fullpath'));
-            obj.wsDir = fullfile(obj.testDir,'..');
             obj.testAppDir = fullfile(obj.testDir,'CompilationTests\');
             obj.applicationsDir = applicationsDir;
+            
         end
+    
     end
     
     methods(TestClassSetup)
-        function copyInputFiles(testCase)
+        
+        function setupInputFiles(testCase)
             try
                 bdclose('all');
             
@@ -74,14 +73,11 @@ classdef compilationTest < matlab.unittest.TestCase
                         fullfile(filesToCopy(i).dest, filesToCopy(i).name));
                 end
             catch
-                fprintf(['\nWEC-Sim Applications directory not set correctly for CI tests.\n'...
+                error(['\nWEC-Sim Applications directory not set correctly for CI tests.\n'...
                     'Change the ''applicationsDir'' variable in wecSimTest.m to run \n' ...
                     'the compilation tests using the applications repo cases.\n\n']);
-                testCase.runComp = 0;
             end
-        end
-        
-        function editInputFiles(testCase)
+            
             % B2B #4
             fileID = fopen(fullfile(testCase.testAppDir, '\Body-to-Body_Interactions\B2B_Case4\wecSimInputFile.m'),'a');
             fprintf(fileID,'%s\n',"simu.explorer = 'off';");
@@ -175,12 +171,13 @@ classdef compilationTest < matlab.unittest.TestCase
             fprintf(fileID,'%s\n',"simu.dt = 0.001;");
             fclose(fileID);
         end
+       
     end
     
     methods(TestClassTeardown)
         function removeInputFiles(testCase)
             bdclose('all');
-            cd(testCase.wsDir)
+            cd(testCase.testDir)
             rmpath(testCase.testAppDir);
             rmdir(testCase.testAppDir,'s');
         end
@@ -189,7 +186,6 @@ classdef compilationTest < matlab.unittest.TestCase
     methods(Test)
         function b2b_4(testCase)
             % B2B, regularCIC wave, ode4
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Body-to-Body_Interactions\B2B_Case4'));
             wecSim
             clear body constraint output pto simu waves
@@ -197,7 +193,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function b2b_6(testCase)
             % B2B + SS, regularCIC wave, ode4
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Body-to-Body_Interactions\B2B_Case6'));
             wecSim
             clear body constraint output pto simu waves
@@ -205,7 +200,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function decay(testCase)
             % Decay case, nowaveCIC, Morison element
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Free_Decay\1m-ME'));
             wecSim
             clear body constraint output pto simu waves
@@ -213,7 +207,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function gbm(testCase)
             % GBM, ode45, regular wave
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Generalized_Body_Modes'));
             wecSim
             clear body constraint output pto simu waves
@@ -221,7 +214,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function mcr(testCase)
             % MCR, spectrum import, MCR case file import
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Multiple_Condition_Runs\RM3_MCROPT3_SeaState'));
             wecSimMCR
             clear body constraint output pto simu waves mcr imcr
@@ -229,7 +221,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function mooring(testCase)
             % Mooring matrix
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Mooring\MooringMatrix'));
             wecSim
             clear body constraint output pto simu waves
@@ -237,7 +228,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function nhBody(testCase)
             % Nonhydro body
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Nonhydro_Body'));
             wecSim
             clear body constraint output pto simu waves
@@ -245,7 +235,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function paraview(testCase)
             % Paraview, nonlinear hydro, accelerator
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Paraview_Visualization\OSWEC_NonLinear_Viz'));
             wecSim
             clear body constraint output pto simu waves
@@ -253,7 +242,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function yaw(testCase)
             % Passive Yaw, morison element
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'Passive_Yaw\PassiveYawON'));
             wecSim
             clear body constraint output pto simu waves
@@ -261,7 +249,6 @@ classdef compilationTest < matlab.unittest.TestCase
         
         function wecccomp(testCase)
             % Passive Yaw, morison element
-            testCase.assumeEqual(testCase.runComp,1,'Test off (runComp=0).')
             cd(fullfile(testCase.testAppDir, 'WECCCOMP_Fault_Implementation\'));
             wecSim
             clear body constraint output pto simu waves

--- a/tests/regressionTest.m
+++ b/tests/regressionTest.m
@@ -1,407 +1,468 @@
 classdef regressionTest < matlab.unittest.TestCase
     
     properties
-        testDir = '';
-        wsDir = '';
-        testRegDir = '';
-        runReg = [];       % 1 to run regular wave simulations
-        runIrreg = [];     % 1 to run irregular wave simulations
-        runYaw = [];       % 1 to run passive yaw simulations
-        plotNO = [];       % 1 to plot new run vs. stored run for comparison of each solver
-        plotSolvers = [];  % 1 to plot new run comparison by sln method
-        openCompare = [];  % 1 opens all new run vs. stored run plots for comparison of each solver
-        
+        testDir = ''
+        plotNO = []       % 1 to plot new run vs. stored run for comparison of each solver
+        plotSolvers = []  % 1 to plot new run comparison by sln method
+        openCompare = []  % 1 opens all new run vs. stored run plots for comparison of each solver
+        regular
+        regularCIC
+        regularSS
+        irregularCIC
+        irregularSS
+        RegYaw
+        IrrYaw
+        OriginalDefault
     end
     
     methods(Access = 'public')
-        function obj = regressionTest(runReg, runIrreg, runYaw, plotNO, plotSolvers, openCompare)
+        
+        function obj = regressionTest(plotNO, plotSolvers, openCompare)
+            
             arguments
-                runReg      (1,1) double = 1;
-                runIrreg    (1,1) double = 1;
-                runYaw      (1,1) double = 1;
-                plotNO      (1,1) double = 1;
-                plotSolvers (1,1) double = 1;
-                openCompare (1,1) double = 1;
+                plotNO      (1,1) double = 1
+                plotSolvers (1,1) double = 1
+                openCompare (1,1) double = 1
             end
             
             % Assign arguments to test Class
-            obj.runReg = runReg;
-            obj.runIrreg = runIrreg;
-            obj.runYaw = runYaw;
             obj.plotNO = plotNO;
             obj.plotSolvers = plotSolvers;
             obj.openCompare = openCompare;
             
-            % Set WEC-Sim, test and case directories
+            % Set test directory
             obj.testDir = fileparts(mfilename('fullpath'));
-            obj.wsDir = fullfile(obj.testDir,'..');
-            obj.testRegDir = fullfile(obj.testDir,'RegressionTests\');
             
-            % Add directories to path
-            addpath(genpath(obj.testRegDir))
+            % Save the visibility state at construction
+            obj.OriginalDefault = get(0,'DefaultFigureVisible');
+            
+        end
+        
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
         end
     end
     
     methods(TestClassSetup)
-        function runRegTests(testCase)
-            if testCase.runReg==1
-                cd(fullfile(testCase.testDir,'RegressionTests'))
-                cd RegularWaves/regular; runLoadRegular; cd .. ;
-                savefig('figReg');
-                cd regularCIC; runLoadRegularCIC; cd .. ;
-                savefig('figRegCIC');
-                cd regularSS; runLoadRegularSS; cd .. ;
-                savefig('figRegSS');
-                close all;
-            end
+        
+        function runRegTest(testCase)
+            
+            cd(fullfile(testCase.testDir,       ...
+                        'RegressionTests',      ...
+                        'RegularWaves',         ...
+                        'regular'))
+            
+            runLoadRegular;
+            testCase.regular = load('regular.mat').("regular");
+            savefig(fullfile('..', 'figReg'));
+            
             cd(testCase.testDir);
+            
         end
         
-        function runIrregTests(testCase)
-            if testCase.runIrreg==1
-                cd(fullfile(testCase.testDir,'RegressionTests'))    
-                cd IrregularWaves/irregularCIC; runLoadIrregularCIC; cd ..;
-                savefig('figIrregCIC') ;
-                cd irregularSS; runLoadIrregularSS; cd ..;
-                savefig('figIrregSS');
-                close all;
-            end
+        function runRegCICTest(testCase)
+            
+            cd(fullfile(testCase.testDir,       ...
+                        'RegressionTests',      ...
+                        'RegularWaves',         ...
+                        'regularCIC'))
+            
+            runLoadRegularCIC;
+            testCase.regularCIC = load('regularCIC.mat').("regularCIC");
+            savefig(fullfile('..', 'figRegCIC'));
+            
             cd(testCase.testDir);
+            
         end
         
-        function runYawTests(testCase)
-            if testCase.runYaw==1
-                cd(fullfile(testCase.testDir,'RegressionTests'))
-                cd PassiveYaw/RegularWaves; runLoadPassiveYawReg; cd ..;
-                savefig('figYawReg');
-                cd IrregularWaves; runLoadPassiveYawIrr; cd .. ;
-                savefig('figYawIrr');
-                close all;
-                cd(fullfile(testCase.testDir));
-            end
+        function runRegSSTest(testCase)
+            
+            cd(fullfile(testCase.testDir,       ...
+                        'RegressionTests',      ...
+                        'RegularWaves',         ...
+                        'regularSS'))
+            
+            runLoadRegularSS;
+            testCase.regularSS = load('regularSS.mat').("regularSS");
+            savefig(fullfile('..', 'figRegSS'));
+            
             cd(testCase.testDir);
+        
+        end
+        
+        function runIrregCICTest(testCase)
+            
+            cd(fullfile(testCase.testDir,   ...
+                        'RegressionTests',  ...
+                        'IrregularWaves',   ...
+                        'irregularCIC'))
+                    
+            runLoadIrregularCIC;
+            testCase.irregularCIC = ...
+                                load('irregularCIC.mat').("irregularCIC");
+            savefig(fullfile('..', 'figIrregCIC'));
+            
+            cd(testCase.testDir);
+            
+        end
+        
+        function runIrregSSTest(testCase)
+            
+            cd(fullfile(testCase.testDir,   ...
+                        'RegressionTests',  ...
+                        'IrregularWaves',   ...
+                        'irregularSS'))
+                    
+            runLoadIrregularSS;
+            testCase.irregularSS = load('irregularSS.mat').("irregularSS");
+            savefig(fullfile('..', 'figIrregSS'));
+            
+            cd(testCase.testDir);
+            
+        end
+        
+        function runYawRegTest(testCase)
+            
+            cd(fullfile(testCase.testDir,   ...
+                        'RegressionTests',  ...
+                        'PassiveYaw',       ...
+                        'RegularWaves'))
+                    
+            runLoadPassiveYawReg;
+            testCase.RegYaw = load('RegYaw.mat').("RegYaw");
+            savefig(fullfile('..', 'figYawReg'));
+            
+            cd(testCase.testDir);
+            
+        end
+        
+        function runYawIrrTest(testCase)
+            
+            cd(fullfile(testCase.testDir,   ...
+                        'RegressionTests',  ...
+                        'PassiveYaw',       ...
+                        'IrregularWaves'))
+                    
+            runLoadPassiveYawIrr;
+            testCase.IrrYaw = load('IrrYaw.mat').("IrrYaw");
+            savefig(fullfile('..', 'figYawIrr'));
+            
+            cd(testCase.testDir);
+            
         end
         
     end
     
     methods(TestClassTeardown)
+        
         function plotRegTests(testCase)
-            load('regular.mat','regular');
-            load('regularCIC.mat','regularCIC');
-            load('regularSS.mat','regularSS');
-            load('irregularCIC.mat','irregularCIC');
-            load('irregularSS.mat','irregularSS');
-            load('RegYaw.mat','RegYaw');
-            load('IrrYaw.mat','IrrYaw');
             
+            regular = testCase.regular;
+            regularCIC = testCase.regularCIC;
+            regularSS = testCase.regularSS;
+            irregularCIC = testCase.irregularCIC;
+            irregularSS = testCase.irregularSS;
+            RegYaw = testCase.RegYaw;
+            IrrYaw = testCase.IrrYaw;
+
             % Plot Solver Comparisons
-            if testCase.plotSolvers==1
-                if testCase.runReg==1
-                    cd(fullfile(testCase.testDir,'RegressionTests'));
-                    cd RegularWaves; printPlotRegular;
-                end
-                if testCase.runIrreg==1
-                    cd(fullfile(testCase.testDir,'RegressionTests'));
-                    cd IrregularWaves; printPlotIrregular;
-                end
+            if testCase.plotSolvers == 1
+                
+                cd(fullfile(testCase.testDir,   ...
+                            'RegressionTests',  ...
+                            'RegularWaves'));
+                printPlotRegular;
+                
+                cd(fullfile(testCase.testDir,   ...
+                            'RegressionTests',  ...
+                            'IrregularWaves'));
+                printPlotIrregular;
+                
             end
 
             % Open new vs. org Comparisons
-            if testCase.openCompare==1
-                if testCase.runReg==1
-                    cd(fullfile(testCase.testDir,'RegressionTests'));
-                    cd RegularWaves; openfig('figReg.fig'); openfig('figRegCIC.fig'); openfig('figRegSS.fig');
-                end
-                if testCase.runIrreg==1
-                    cd(fullfile(testCase.testDir,'RegressionTests'));
-                    cd IrregularWaves; openfig('figIrregCIC.fig'); openfig('figIrregSS.fig');
-                end
-                if testCase.runYaw==1
-                    cd(fullfile(testCase.testDir,'RegressionTests'));
-                    cd PassiveYaw; open('figYawReg.fig'); open('figYawIrr.fig'); 
-                end
+            if testCase.openCompare == 1
+                
+                cd(fullfile(testCase.testDir,   ...
+                            'RegressionTests',  ...
+                            'RegularWaves'));
+                openfig('figReg.fig');
+                openfig('figRegCIC.fig');
+                openfig('figRegSS.fig');
+                
+                cd(fullfile(testCase.testDir,   ...
+                            'RegressionTests',  ...
+                            'IrregularWaves'));
+                openfig('figIrregCIC.fig');
+                openfig('figIrregSS.fig');
+                
+                cd(fullfile(testCase.testDir,   ...
+                            'RegressionTests',  ...
+                            'PassiveYaw'));
+                open('figYawReg.fig'); 
+                open('figYawIrr.fig'); 
+                
             end
             
-            cd(testCase.wsDir);
-            rmpath(genpath(testCase.testRegDir));
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+            
         end
     end
     
     methods(Test)
+        
         function body1_reg_disp_heave(testCase)
             % Body1 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regular.mat','regular');
             tol = 1e-10;
-            org = regular.B1.WEC_Sim_org.heave;
-            new = regular.B1.WEC_Sim_new.heave;
+            org = testCase.regular.B1.WEC_Sim_org.heave;
+            new = testCase.regular.B1.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body1 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function body2_reg_disp_heave(testCase)
             % Body2 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regular.mat','regular');
             tol = 1e-10;
-            org = regular.B2.WEC_Sim_org.heave;
-            new = regular.B2.WEC_Sim_new.heave;
+            org = testCase.regular.B2.WEC_Sim_org.heave;
+            new = testCase.regular.B2.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body2 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body2 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function bodyRel_reg_disp_heave(testCase)
             % Relative Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regular.mat','regular');
             tol = 1e-10;
-            org = regular.Rel.WEC_Sim_org.heave;
-            new = regular.Rel.WEC_Sim_new.heave;
+            org = testCase.regular.Rel.WEC_Sim_org.heave;
+            new = testCase.regular.Rel.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Relative Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Relative Displacement in Heave, Diff = '  ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         
         function body1_regCIC_disp_heave(testCase)
             % Body1 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularCIC.mat','regularCIC');
             tol = 1e-10;
-            org = regularCIC.B1.WEC_Sim_org.heave;
-            new = regularCIC.B1.WEC_Sim_new.heave;
+            org = testCase.regularCIC.B1.WEC_Sim_org.heave;
+            new = testCase.regularCIC.B1.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body1 Displacement in Heave, Diff = '     ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function body2_regCIC_disp_heave(testCase)
             % Body2 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularCIC.mat','regularCIC');
             tol = 1e-10;
-            org = regularCIC.B2.WEC_Sim_org.heave;
-            new = regularCIC.B2.WEC_Sim_new.heave;
+            org = testCase.regularCIC.B2.WEC_Sim_org.heave;
+            new = testCase.regularCIC.B2.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body2 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body2 Displacement in Heave, Diff = '     ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function bodyRel_regCIC_disp_heave(testCase)
             % Relative Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularCIC.mat','regularCIC');
             tol = 1e-10;
-            org = regularCIC.Rel.WEC_Sim_org.heave;
-            new = regularCIC.Rel.WEC_Sim_new.heave;
+            org = testCase.regularCIC.Rel.WEC_Sim_org.heave;
+            new = testCase.regularCIC.Rel.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Relative Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Relative Displacement in Heave, Diff = '  ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         
         function body1_regSS_disp_heave(testCase)
             % Body1 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularSS.mat','regularSS');
             tol = 1e-10;
-            org = regularSS.B1.WEC_Sim_org.heave;
-            new = regularSS.B1.WEC_Sim_new.heave;
+            org = testCase.regularSS.B1.WEC_Sim_org.heave;
+            new = testCase.regularSS.B1.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body1 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function body2_regSS_disp_heave(testCase)
             % Body2 Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularSS.mat','regularSS');
             tol = 1e-10;
-            org = regularSS.B2.WEC_Sim_org.heave;
-            new = regularSS.B2.WEC_Sim_new.heave;
+            org = testCase.regularSS.B2.WEC_Sim_org.heave;
+            new = testCase.regularSS.B2.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body2 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body2 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function bodyRel_regSS_disp_heave(testCase)
             % Relative Displacement in Heave
-            testCase.assumeEqual(testCase.runReg,1,'Test off (runReg=0).');
-            load('regularSS.mat','regularSS');
             tol = 1e-10;
-            org = regularSS.Rel.WEC_Sim_org.heave;
-            new = regularSS.Rel.WEC_Sim_new.heave;
+            org = testCase.regularSS.Rel.WEC_Sim_org.heave;
+            new = testCase.regularSS.Rel.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Relative Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Relative Displacement in Heave, Diff = '  ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         
         function body1_irreg_disp_heave(testCase)
             % Body1 Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularCIC.mat','irregularCIC');
             tol = 1e-10;
-            org = irregularCIC.B1.WEC_Sim_org.heave;
-            new = irregularCIC.B1.WEC_Sim_new.heave;
+            org = testCase.irregularCIC.B1.WEC_Sim_org.heave;
+            new = testCase.irregularCIC.B1.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body1 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function body2_irreg_disp_heave(testCase)
             % Body2 Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularCIC.mat','irregularCIC');
             tol = 1e-10;
-            org = irregularCIC.B2.WEC_Sim_org.heave;
-            new = irregularCIC.B2.WEC_Sim_new.heave;
+            org = testCase.irregularCIC.B2.WEC_Sim_org.heave;
+            new = testCase.irregularCIC.B2.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body2 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body2 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function bodyRel_irreg_disp_heave(testCase)
             % Relative Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularCIC.mat','irregularCIC');
             tol = 1e-10;
-            org = irregularCIC.Rel.WEC_Sim_org.heave;
-            new = irregularCIC.Rel.WEC_Sim_new.heave;
+            org = testCase.irregularCIC.Rel.WEC_Sim_org.heave;
+            new = testCase.irregularCIC.Rel.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Relative Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Relative Displacement in Heave, Diff = '  ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function irreg_0th_Spectral_Moment(testCase)
             % 0th Order Spectral Moment
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularCIC.mat','irregularCIC');
             tol = 1e-10;
-            org = irregularCIC.Sp.WEC_Sim_org.m0;
-            new = irregularCIC.Sp.WEC_Sim_new.m0;
+            org = testCase.irregularCIC.Sp.WEC_Sim_org.m0;
+            new = testCase.irregularCIC.Sp.WEC_Sim_new.m0;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['0th Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['0th Order Spectral Moment, Diff = '       ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function irreg_2nd_Spectral_Moment(testCase)
             % 2nd Order Spectral Moment
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularCIC.mat','irregularCIC');
             tol = 1e-10;
-            org = irregularCIC.Sp.WEC_Sim_org.m2;
-            new = irregularCIC.Sp.WEC_Sim_new.m2;
+            org = testCase.irregularCIC.Sp.WEC_Sim_org.m2;
+            new = testCase.irregularCIC.Sp.WEC_Sim_new.m2;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['2nd Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['2nd Order Spectral Moment, Diff = '       ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         
         function body1_irregSS_disp_heave(testCase)
             % Body1 Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularSS.mat','irregularSS');
             tol = 1e-10;
-            org = irregularSS.B1.WEC_Sim_org.heave;
-            new = irregularSS.B1.WEC_Sim_new.heave;
+            org = testCase.irregularSS.B1.WEC_Sim_org.heave;
+            new = testCase.irregularSS.B1.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body1 Displacement in Heave, Diff = '     ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function body2_irregSS_disp_heave(testCase)
             % Body2 Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularSS.mat','irregularSS');
             tol = 1e-10;
-            org = irregularSS.B2.WEC_Sim_org.heave;
-            new = irregularSS.B2.WEC_Sim_new.heave;
+            org = testCase.irregularSS.B2.WEC_Sim_org.heave;
+            new = testCase.irregularSS.B2.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Body2 Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Body2 Displacement in Heave, Diff = '     ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function bodyRel_irregSS_disp_heave(testCase)
             % Relative Displacement in Heave
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularSS.mat','irregularSS');
             tol = 1e-10;
-            org = irregularSS.Rel.WEC_Sim_org.heave;
-            new = irregularSS.Rel.WEC_Sim_new.heave;
+            org = testCase.irregularSS.Rel.WEC_Sim_org.heave;
+            new = testCase.irregularSS.Rel.WEC_Sim_new.heave;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['Relative Displacement in Heave, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['Relative Displacement in Heave, Diff = '  ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function irregSS_0th_Spectral_Moment(testCase)
             % 0th Order Spectral Moment
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularSS.mat','irregularSS');
             tol = 1e-10;
-            org = irregularSS.Sp.WEC_Sim_org.m0;
-            new = irregularSS.Sp.WEC_Sim_new.m0;
+            org = testCase.irregularSS.Sp.WEC_Sim_org.m0;
+            new = testCase.irregularSS.Sp.WEC_Sim_new.m0;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['0th Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['0th Order Spectral Moment, Diff = '       ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         function irregSS_2nd_Spectral_Moment(testCase)
             % 2nd Order Spectral Moment
-            testCase.assumeEqual(testCase.runIrreg,1,'Test off (runIrreg=0).');
-            load('irregularSS.mat','irregularSS');
             tol = 1e-10;
-            org = irregularSS.Sp.WEC_Sim_org.m2;
-            new = irregularSS.Sp.WEC_Sim_new.m2;
+            org = testCase.irregularSS.Sp.WEC_Sim_org.m2;
+            new = testCase.irregularSS.Sp.WEC_Sim_new.m2;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['2nd Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['2nd Order Spectral Moment, Diff = '       ...
+                     num2str(max(abs(org-new))) '\n']);
         end
         
         
         function body1_regYaw_disp_yaw(testCase)
             % Body1 Displacement in Yaw
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('RegYaw','RegYaw');
             tol = 1e-10;
-            testCase.verifyEqual(RegYaw.Pos_diff,0,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Yaw, Diff = ' num2str(RegYaw.Pos_diff) '\n']);
+            testCase.verifyEqual(testCase.RegYaw.Pos_diff,0,'AbsTol',tol);
+            fprintf(['Body1 Displacement in Yaw, Diff = '       ...
+                     num2str(testCase.RegYaw.Pos_diff) '\n']);
         end
         
         function body1_regYaw_torque_yaw(testCase)
             % Body1 Torque in Yaw
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('RegYaw','RegYaw');
             tol=1e-4;
-            testCase.verifyEqual(RegYaw.Force_diff,0,'AbsTol',tol);
-            fprintf(['Body1 Torque in Yaw, Diff = ' num2str(RegYaw.Force_diff) '\n']);
+            testCase.verifyEqual(testCase.RegYaw.Force_diff,0,'AbsTol',tol);
+            fprintf(['Body1 Torque in Yaw, Diff = '             ...
+                     num2str(testCase.RegYaw.Force_diff) '\n']);
         end
-        
         
         function body1_irregYaw_disp_yaw(testCase)
             % Body1 Displacement in Yaw
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('IrrYaw','IrrYaw');
             tol = 1e-10;
-            testCase.verifyEqual(IrrYaw.Pos_diff,0,'AbsTol',tol);
-            fprintf(['Body1 Displacement in Yaw, Diff = ' num2str(IrrYaw.Pos_diff) '\n']);
+            testCase.verifyEqual(testCase.IrrYaw.Pos_diff,0,'AbsTol',tol);
+            fprintf(['Body1 Displacement in Yaw, Diff = '       ...
+                     num2str(testCase.IrrYaw.Pos_diff) '\n']);
         end
 
         function body1_irregYaw_torque_yaw(testCase)
             % Body1 Torque in Yaw
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('IrrYaw','IrrYaw');
             tol = 1e-4;
-            testCase.verifyEqual(IrrYaw.Force_diff,0,'AbsTol',tol);
-            fprintf(['Body1 Torque in Yaw, Diff = ' num2str(IrrYaw.Force_diff) '\n']);
+            testCase.verifyEqual(testCase.IrrYaw.Force_diff,0,'AbsTol',tol);
+            fprintf(['Body1 Torque in Yaw, Diff = '             ...
+                     num2str(testCase.IrrYaw.Force_diff) '\n']);
         end
         
         function irregYaw_0th_Spectral_Moment(testCase)
             % 0th Order Spectral Moment
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('IrrYaw','IrrYaw');
             tol = 1e-10;
-            org = IrrYaw.Sp.WEC_Sim_org.m0;
-            new = IrrYaw.Sp.WEC_Sim_new.m0;
+            org = testCase.IrrYaw.Sp.WEC_Sim_org.m0;
+            new = testCase.IrrYaw.Sp.WEC_Sim_new.m0;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['0th Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['0th Order Spectral Moment, Diff = '       ...
+                      num2str(max(abs(org-new))) '\n']);
         end
         
         function irregYaw_2nd_Spectral_Moment(testCase)
             % 2nd Order Spectral Moment
-            testCase.assumeEqual(testCase.runYaw,1,'Test off (runYaw=0).');
-            load('IrrYaw','IrrYaw');
             tol = 1e-10;
-            org = IrrYaw.Sp.WEC_Sim_org.m2;
-            new = IrrYaw.Sp.WEC_Sim_new.m2;
+            org = testCase.IrrYaw.Sp.WEC_Sim_org.m2;
+            new = testCase.IrrYaw.Sp.WEC_Sim_new.m2;
             testCase.verifyEqual(new,org,'AbsTol',tol);
-            fprintf(['2nd Order Spectral Moment, Diff = ' num2str(max(abs(org-new))) '\n']);
+            fprintf(['2nd Order Spectral Moment, Diff = '       ...
+                     num2str(max(abs(org-new))) '\n']);
         end
-
-        
         
     end
+    
 end

--- a/tests/rotationTest.m
+++ b/tests/rotationTest.m
@@ -3,18 +3,10 @@ classdef rotationTest < matlab.unittest.TestCase
     properties
         testDir = '';
         wsDir = '';
-        runRotation = [];
     end
     
     methods (Access = 'public')
-        function obj = rotationTest(runRotation)
-            arguments
-                runRotation (1,1) double = 1;
-            end
-            
-            % Assign arguments to test Class
-            obj.runRotation = runRotation;
-            
+        function obj = rotationTest()
             % Set WEC-Sim, test and applications directories
             obj.testDir = fileparts(mfilename('fullpath'));
             obj.wsDir = fullfile(obj.testDir,'..');
@@ -23,9 +15,7 @@ classdef rotationTest < matlab.unittest.TestCase
     
     methods(Test)
         function setInitDisp_0deg(testCase)
-            % setInitDisp - 0 deg rotation
-            testCase.assumeEqual(testCase.runRotation,1,'Test off (runRotation=0).')
-            
+            % setInitDisp - 0 deg rotation            
             tol = 1e-12;
             bodytest = bodyClass('');
             bodytest.setInitDisp([1 1 1],[1 0 0 pi; 0 1 0 pi; 0 0 1 pi],[0 0 0]);
@@ -36,9 +26,7 @@ classdef rotationTest < matlab.unittest.TestCase
         end
         
         function setInitDisp_inverted(testCase)
-            % setInitDisp - inverted rotation
-            testCase.assumeEqual(testCase.runRotation,1,'Test off (runRotation=0).')
-            
+            % setInitDisp - inverted rotation            
             tol = 1e-12;
             bodytest = bodyClass('');
             bodytest.setInitDisp([1 1 1],[1 0 0 pi/2; 0 1 0 pi/2; 0 0 1 -pi/2],[0 0 0]);
@@ -49,9 +37,7 @@ classdef rotationTest < matlab.unittest.TestCase
         end
         
         function setInitDisp_90deg_y(testCase)
-            % setInitDisp - 90 deg in y
-            testCase.assumeEqual(testCase.runRotation,1,'Test off (runRotation=0).')
-            
+            % setInitDisp - 90 deg in y            
             tol = 1e-12;
             bodytest = bodyClass('');
             bodytest.setInitDisp([1 1 1],[1 0 0 pi/2; 0 0 1 pi/2; 1 0 0 -pi/2],[0 0 0]);
@@ -61,9 +47,7 @@ classdef rotationTest < matlab.unittest.TestCase
         end
         
         function rotMat2AxisAngle_0deg(testCase)
-            % rotMat to axisAngle 0 deg special case
-            testCase.assumeEqual(testCase.runRotation,1,'Test off (runRotation=0).')
-            
+            % rotMat to axisAngle 0 deg special case            
             tol = 1e-12;
             rotMat = [1 0 0; 0 1 0; 0 0 1];
             [axis,angle] = rotMat2AxisAngle(rotMat);
@@ -74,9 +58,7 @@ classdef rotationTest < matlab.unittest.TestCase
         end
         
         function rotMat2AxisAngle_180deg(testCase)
-            % rotMat to axisAngle to 180 deg special case
-            testCase.assumeEqual(testCase.runRotation,1,'Test off (runRotation=0).')
-            
+            % rotMat to axisAngle to 180 deg special case            
             tol = 1e-12;
             rotMat = [1 0 0; 0 -1 0; 0 0 -1];
             [axis,angle] = rotMat2AxisAngle(rotMat);

--- a/tests/runFromSimTest.m
+++ b/tests/runFromSimTest.m
@@ -4,17 +4,11 @@ classdef runFromSimTest < matlab.unittest.TestCase
         testDir = '';
         wsDir = '';
         runFromSimDir = '';
-        runFromSim = [];
     end
     
     methods (Access = 'public')
-        function obj = runFromSimTest(runFromSim)
-            arguments
-                runFromSim (1,1) double = 1;
-            end
-            
-            % Assign arguments to test Class
-            obj.runFromSim = runFromSim;
+        
+        function obj = runFromSimTest()
             
             % Set WEC-Sim, test and simulink directories
             obj.testDir = fileparts(mfilename('fullpath'));
@@ -24,7 +18,9 @@ classdef runFromSimTest < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
-        function copyInputFiles(testCase)
+        
+        function setupInputFiles(testCase)
+            
             bdclose('all');
             
             % Create directory if necessary
@@ -47,9 +43,7 @@ classdef runFromSimTest < matlab.unittest.TestCase
                 fullfile(testCase.runFromSimDir,'fromSimCustom.slx'));
             
             cd(testCase.runFromSimDir);
-        end
         
-        function editInputFiles(testCase)
             % Set proper parameters fromSimInput case
             load_system('fromSimInput.slx');
             
@@ -134,7 +128,6 @@ classdef runFromSimTest < matlab.unittest.TestCase
     methods(Test)
         function fromSimCustom(testCase)
             % Run WEC-Sim from Simulink with custom parameters
-            testCase.assumeEqual(testCase.runFromSim,1,'Test off (runFromSim=0).')
             cd(testCase.runFromSimDir)
             
             simFile = fullfile(testCase.runFromSimDir,'fromSimCustom.slx');
@@ -149,7 +142,6 @@ classdef runFromSimTest < matlab.unittest.TestCase
         
         function fromSimInput(testCase)
             % Run WEC-Sim from Simulink with input file
-            testCase.assumeEqual(testCase.runFromSim,1,'Test off (runFromSim=0).')
             cd(testCase.runFromSimDir)
             
             simFile = fullfile(testCase.runFromSimDir,'fromSimInput.slx');

--- a/wecSimTest.m
+++ b/wecSimTest.m
@@ -1,3 +1,47 @@
+function results = wecSimTest(options)
+
+    arguments
+        options.bemioTest = true
+        options.regressionTest = true
+        options.compilationTest = true
+        options.runFromSimTest = true
+        options.rotationTest = true
+    end
+
+    import matlab.unittest.TestRunner;
+    import matlab.unittest.TestSuite;
+    import matlab.unittest.Test
+
+    suites = Test.empty();
+
+    if options.bemioTest
+        suites = [suites TestSuite.fromFile('tests/bemioTest.m')];
+    end
+    
+    if options.regressionTest
+        suites = [suites TestSuite.fromFile('tests/regressionTest.m')];
+    end
+    
+    if options.compilationTest
+        suites = [suites TestSuite.fromFile('tests/compilationTest.m')];
+    end
+    
+    if options.runFromSimTest
+        suites = [suites TestSuite.fromFile('tests/runFromSimTest.m')];
+    end
+    
+    if options.rotationTest
+        suites = [suites TestSuite.fromFile('tests/rotationTest.m')];
+    end
+    
+    % Build the runner
+    runner = TestRunner.withTextOutput;
+
+    % Run the tests
+    results = runner.run(suites);
+    
+end
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Copyright 2014 the National Renewable Energy Laboratory and Sandia Corporation
 %
@@ -13,67 +57,3 @@
 % See the License for the specific language governing permissions and
 % limitations under the License.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Run Test Cases
-% Use the following command to run tests locally,  "wecSimTest"
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% User Input
-runReg=1;       % 1 to run regular wave simulations
-runIrreg=0;     % 1 to run irregular wave simulations
-runYaw=0;       % 1 to run passive yaw simulations
-runComp=1;      % 1 to run compilation of various cases
-runBEMIO=1;     % 1 to run BEMIO read_X cases
-runFromSim=1;   % 1 to run from Simulink tests
-runRotation=1;  % 1 to run rotation tests for setInitDisp method and axisAngle2RotMat
-plotNO=1;       % 1 to plot new run vs. stored run for comparison of each solver
-plotSolvers=1;  % 1 to plot new run comparison by sln method
-openCompare=1;  % 1 opens all new run vs. stored run plots for comparison of each solver
-
-% Hide figures
-set(0,'DefaultFigureVisible','off')
-
-% Directory variables
-wsDir = pwd;
-testDir = fullfile(wsDir,'tests');
-testAppDir = fullfile(testDir,'CompilationTests\WEC-Sim_Applications');
-applicationsDir = fullfile(wsDir,'..\WEC-Sim_Applications\');
-
-addpath(testDir)
-% suite = matlab.unittest.TestSuite.fromFolder(testDir);
-
-% Initialize Tests
-bemTest = bemioTest(runBEMIO);
-regTest = regressionTest(runReg, runIrreg, runYaw, plotNO, plotSolvers, openCompare);
-cmpTest = compilationTest(applicationsDir,runComp);
-simTest = runFromSimTest(runFromSim);
-rotTest = rotationTest(runRotation);
-
-% Run tests
-cmpResults = cmpTest.run;
-regResults = regTest.run;
-bemResults = bemTest.run;
-simResults = simTest.run;
-rotResults = rotTest.run;
-
-% Reprint results (WEC-Sim runs clear command window)
-disp('BEMIO Test Results: ');
-disp(bemResults);
-
-disp('Regression Test Results: ');
-disp(regResults);
-
-disp('Compilation Test Results: ');
-disp(cmpResults);
-
-disp('Run From Simulink Test Results: ');
-disp(simResults);
-
-disp('Rotation Test Results: ');
-disp(rotResults);
-
-% Clean-up
-cd(wsDir)
-rmpath(testDir);
-set(0,'DefaultFigureVisible','on')


### PR DESCRIPTION
Hey Adam,

I put this together this morning to use test suites to control the execution of the different tests rather than relying on a bespoke script with printing (yuck).

I took away all of test "test this / test that" flags in the test classes, because you should use test suites to control the execution of which tests you want to run. There are a number of ways to do it.

I also worked a bit on the path gymnastics that was going on in the regression tests to simplify the commands a bit.

The compilation tests (these names!) do not work for me, at present. For some reason it's not copying the hydrodata directories:

```
Error occurred in compilationTest/wecccomp and it did not run to completion.
    ---------
    Error ID:
    ---------
    ''
    --------------
    Error Details:
    --------------
    Error using bodyClass/checkinputs (line 456)
    The hdf5 file hydroData/wavestar.h5 does not exist
    
    Error in wecSimInitialize (line 145)
        body(ii).checkinputs(simu.morisonElement);
    
    Error in run (line 91)
    evalin('caller', strcat(script, ';'));
    
    Error in wecSim (line 44)
    run('wecSimInitialize');
    
    Error in compilationTest/wecccomp (line 253)
                wecSim
============================
```

This just increases my conviction that file copying should stop and that the wec-sim application tests are in the wrong place.

