### PR TITLE
Docs Updates for Main Branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,8 +67,9 @@ jobs:
           touch ${{ env.BUILD_DIR }}/.nojekyll
           cp docs/_assets/gh-pages.gitignore ${{ env.BUILD_DIR }}/.gitignore
           cp docs/_assets/gh-pages-redirect.html ${{ env.BUILD_DIR }}/index.html
-          cp docs/_assets/gh-pages-redirect.html ${{ env.BUILD_DIR }}/master/index.html
           cp docs/_assets/gh-pages-readme.md ${{ env.BUILD_DIR }}/README.md
+          mkdir ${{ env.BUILD_DIR }}/master
+          cp docs/_assets/gh-pages-redirect.html ${{ env.BUILD_DIR }}/master/index.html
       - name: Deploy
         if: ${{ github.event_name == 'push' && (env.BRANCH == 'dev' || env.BRANCH == 'main') }}
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,7 @@ jobs:
           touch ${{ env.BUILD_DIR }}/.nojekyll
           cp docs/_assets/gh-pages.gitignore ${{ env.BUILD_DIR }}/.gitignore
           cp docs/_assets/gh-pages-redirect.html ${{ env.BUILD_DIR }}/index.html
+          cp docs/_assets/gh-pages-redirect.html ${{ env.BUILD_DIR }}/master/index.html
           cp docs/_assets/gh-pages-readme.md ${{ env.BUILD_DIR }}/README.md
       - name: Deploy
         if: ${{ github.event_name == 'push' && (env.BRANCH == 'dev' || env.BRANCH == 'main') }}

--- a/docs/_assets/gh-pages-redirect.html
+++ b/docs/_assets/gh-pages-redirect.html
@@ -5,6 +5,6 @@
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url=./main/index.html">
     <meta name="description" content="WEC-Sim is a versatile open-source simulation platform for wave energy converter devices. Simulate, design, and optimize your wave energy systems with WEC-Sim to harness clean and renewable energy from ocean waves."
-    <link rel="canonical" href="https://wec-sim.github.io/WEC-Sim/master/index.html">
+    <link rel="canonical" href="https://wec-sim.github.io/WEC-Sim/main/index.html">
   </head>
 </html>

--- a/docs/_assets/gh-pages-redirect.html
+++ b/docs/_assets/gh-pages-redirect.html
@@ -3,7 +3,7 @@
   <head>
     <title>Redirecting to main branch</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./main/index.html">
+    <meta http-equiv="refresh" content="0; url=/WEC-Sim/main/index.html">
     <meta name="description" content="WEC-Sim is a versatile open-source simulation platform for wave energy converter devices. Simulate, design, and optimize your wave energy systems with WEC-Sim to harness clean and renewable energy from ocean waves."
     <link rel="canonical" href="https://wec-sim.github.io/WEC-Sim/main/index.html">
   </head>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ matlab_src_dir = package_dir.resolve()
 matlab_keep_package_prefix = False
 
 # sphinx_multiversion settings
-smv_branch_whitelist = r'(master|dev)$'
+smv_branch_whitelist = r'(main|dev)$'
 smv_tag_whitelist = 'a^'
 smv_remote_whitelist = r'^(origin)$'
 


### PR DESCRIPTION
This PR is an update to https://github.com/WEC-Sim/WEC-Sim/pull/1235, which adds the following to the gh-pages docs build:

1. Whitelisting the main branch so that it can be build and removing master from the whitelist.
1. A second redirect from the old master/index.html route to main/index.html route.